### PR TITLE
Added MacOS instructions for imagemagick and argument parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ Simple script that translates and/or transcribes video audio to English and adds
 
 _Please note: I've only set this up on a Linux terminal with Python 3.8+. So these instructions might not be entirely right if you're using a non-Unix-based operating system (AKA Windows. MacOS should be fine)._
 
+### MacOS
+
+Install [imagemagick](https://imagemagick.org/script/download.php) for MacOS. You can do this with Homebrew:
+
+```
+brew install imagemagick
+```
+
 ### Virtual Environment
+
 ```
 python -m venv ./venv
 
@@ -14,13 +23,17 @@ source absolute/path/to/activate_file
 
 pip install -r requirements.txt --use-pep517
 ```
+
 ### Environment Variables
+
 ```
 cp env-template .env
 ```
+
 Then paste in your `OPENAI_API_KEY` within the double quotes.
 
 ### Run the Script
+
 ```
-python main.py
+python main.py --video <PATH TO TARGET MP4>
 ```

--- a/main.py
+++ b/main.py
@@ -3,13 +3,19 @@ from dotenv import load_dotenv
 import openai
 from moviepy.editor import TextClip, VideoFileClip, CompositeVideoClip
 from moviepy.video.tools.subtitles import SubtitlesClip
+import argparse
+
+parser = argparse.ArgumentParser(description="Add subtitles to video")
+parser.add_argument("-v", "--video", help="Path to video file", default="sample.mp4")
+args = parser.parse_args()
+config = vars(args)
 
 load_dotenv()
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 # Get path to video file with Python
-video_file_path = os.path.join(os.getcwd(), "sample.mp4")
+video_file_path = config.get("video")
 
 try:
     try:


### PR DESCRIPTION
Not sure what the contributing guidelines are for this but got this running on my MacOS, only thing I had to do was install the  imagemagick open source package. Worked nicely!

**Changes** 
- Updated README.md to include MacOS instructions
- Added argument parsing for calling the script (default is still `sample.py`) so you can optionally specify the path e.g. `python main.py --video '../../my_video.mp4'` (also documented in the README file) 